### PR TITLE
Added 'categories' feature

### DIFF
--- a/savepip/cli.py
+++ b/savepip/cli.py
@@ -2,13 +2,14 @@
 import argparse
 import sys
 from .core import DependencySaver
+from .memory_manager import MemoryManager
 
 def main():
     parser = argparse.ArgumentParser(description="Install packages and save clean dependencies")
     
     parser.add_argument("command", nargs="?", default="install", 
-                      help="Command (install or save)")
-    parser.add_argument("packages", nargs="*", help="Packages to install")
+                      help="Command (install, save, mk-category, use-category, cur-category, ls-category)")
+    parser.add_argument("packages", nargs="*", help="Packages to install or category name")
     parser.add_argument("-m", "--manager", choices=["pip", "conda"], default="pip",
                       help="Package manager to use (default: pip)")
     parser.add_argument("-o", "--output", help="Output file for dependencies")
@@ -16,6 +17,7 @@ def main():
                       help="Upgrade packages if already installed")
     parser.add_argument("-d", "--dev", action="store_true", 
                       help="Save as development dependencies")
+    parser.add_argument("-c", "--categories", nargs="*", help="Categories to save dependencies from")
     
     args = parser.parse_args()
     
@@ -23,14 +25,42 @@ def main():
         parser.print_help()
         return False
     
-    if args.command not in ["install", "save"]:
+    if args.command not in ["install", "save", "mk-category", "use-category", "cur-category", "ls-category"]:
         args.packages.insert(0, args.command)
         args.command = "install"
     
-    saver = DependencySaver(output_file=args.output, manager=args.manager)
+    memory_manager = MemoryManager()
+    
+    if args.command == "mk-category":
+        if not args.packages:
+            print("Please provide a category name.")
+            return False
+        return memory_manager.create_category(args.packages[0])
+    
+    if args.command == "use-category":
+        if not args.packages:
+            print("Please provide a category name.")
+            return False
+        return memory_manager.use_category(args.packages[0])
+    
+    if args.command == "cur-category":
+        current_category = memory_manager.show_current_category()
+        print(f"Current category: {current_category}")
+        return True
+    
+    if args.command == "ls-category":
+        categories = memory_manager.list_categories()
+        for category, is_current in categories:
+            if is_current:
+                print(f"* {category}")
+            else:
+                print(f"  {category}")
+        return True
+    
+    saver = DependencySaver(output_file=args.output, manager=args.manager, memory_manager=memory_manager)
     
     if args.command == "save":
-        return saver._save_dependencies(args.dev)
+        return saver._save_dependencies(args.dev, args.categories)
     else:  # install command
         return saver.install_and_save(args.packages, args.upgrade, args.dev)
 

--- a/savepip/memory_manager.py
+++ b/savepip/memory_manager.py
@@ -1,0 +1,180 @@
+"""
+Memory Manager Module
+
+This module provides the MemoryManager class which handles the storage and
+retrieval of package dependencies categorized under different categories.
+It uses a JSON file to persist the data and ensures a default category is
+always present.
+
+Classes:
+    MemoryManager
+
+Author: Achraf Mataich
+Date: 2025-03-11
+"""
+
+import os
+import json
+
+class MemoryManager:
+    """
+    MemoryManager handles the storage and retrieval of package dependencies
+    categorized under different categories. It uses a JSON file to persist
+    the data and ensures a default category is always present.
+    """
+    def __init__(self):
+        """
+        Initializes the MemoryManager by setting up the base directory,
+        loading the memory from the JSON file, and ensuring the default
+        category exists.
+        """
+        self.base_dir = self._get_base_dir()
+        self.memory_file = os.path.join(self.base_dir, "memory.json")
+        self.memory = self._load_memory()
+        self._ensure_default_category()
+
+    def _get_base_dir(self):
+        """
+        Determines the base directory for storing the memory file.
+        If a virtual environment is active, it uses the virtual environment's
+        directory; otherwise, it uses the user's home directory.
+        
+        Returns:
+            str: The base directory path.
+        """
+        if os.getenv("VIRTUAL_ENV"):
+            return os.path.join(os.getenv("VIRTUAL_ENV"), ".savepip")
+        else:
+            return os.path.join(os.path.expanduser("~"), ".savepip")
+
+    def _load_memory(self):
+        """
+        Loads the memory from the JSON file if it exists. If the file does not
+        exist, it initializes the memory with default values.
+        
+        Returns:
+            dict: The loaded or initialized memory.
+        """
+        if os.path.exists(self.memory_file):
+            with open(self.memory_file, "r") as f:
+                return json.load(f)
+        return {"categories": {}, "current_category": None}
+
+    def _save_memory(self):
+        """
+        Saves the current memory state to the JSON file. Ensures the base
+        directory exists before saving.
+        """
+        os.makedirs(self.base_dir, exist_ok=True)
+        with open(self.memory_file, "w") as f:
+            json.dump(self.memory, f, indent=4)
+
+    def _ensure_default_category(self):
+        """
+        Ensures that a default category exists in the memory. If no current
+        category is set, it sets the default category as the current category.
+        """
+        if "default" not in self.memory["categories"]:
+            self.memory["categories"]["default"] = []
+        if not self.memory["current_category"]:
+            self.memory["current_category"] = "default"
+        self._save_memory()
+
+    def create_category(self, name):
+        """
+        Creates a new category with the given name. If the category already
+        exists, it prints a message and returns False.
+        
+        Args:
+            name (str): The name of the category to create.
+        
+        Returns:
+            bool: True if the category was created, False otherwise.
+        """
+        if name in self.memory["categories"]:
+            print(f"Category '{name}' already exists.")
+            return False
+        self.memory["categories"][name] = []
+        self._save_memory()
+        print(f"Category '{name}' created.")
+        return True
+
+    def use_category(self, name):
+        """
+        Sets the current category to the given name. If the category does not
+        exist, it prints a message and returns False.
+        
+        Args:
+            name (str): The name of the category to switch to.
+        
+        Returns:
+            bool: True if the category was switched, False otherwise.
+        """
+        if name not in self.memory["categories"]:
+            print(f"Category '{name}' does not exist.")
+            return False
+        self.memory["current_category"] = name
+        self._save_memory()
+        print(f"Switched to category '{name}'.")
+        return True
+
+    def add_dependency(self, package):
+        """
+        Adds a package dependency to the current category. If no category is
+        selected, it prints a message and returns False.
+        
+        Args:
+            package (str): The name of the package to add.
+        
+        Returns:
+            bool: True if the package was added, False otherwise.
+        """
+        category = self.memory["current_category"]
+        if not category:
+            print("No category selected.")
+            return False
+        if package not in self.memory["categories"][category]:
+            self.memory["categories"][category].append(package)
+            self._save_memory()
+        return True
+
+    def get_dependencies(self, categories=None):
+        """
+        Retrieves the list of package dependencies for the specified categories.
+        If no categories are specified, it retrieves dependencies for the current
+        category.
+        
+        Args:
+            categories (list, optional): The list of categories to retrieve dependencies for.
+        
+        Returns:
+            list: The list of package dependencies.
+        """
+        if categories is None:
+            categories = [self.memory["current_category"]]
+        dependencies = set()
+        for category in categories:
+            if category in self.memory["categories"]:
+                dependencies.update(self.memory["categories"][category])
+        return list(dependencies)
+
+    def show_current_category(self):
+        """
+        Returns the name of the current category.
+        
+        Returns:
+            str: The name of the current category.
+        """
+        return self.memory["current_category"]
+
+    def list_categories(self):
+        """
+        Lists all categories along with a flag indicating whether each category
+        is the current category.
+        
+        Returns:
+            list: A list of tuples containing the category name and a boolean flag.
+        """
+        categories = self.memory["categories"].keys()
+        current_category = self.memory["current_category"]
+        return [(category, category == current_category) for category in categories]


### PR DESCRIPTION
# Dependencies Categories feature

I have made a way to make categories of installed packages via `savepip` command, so we can save the type of requirements we want without having to delete locally used packages that are not meant to be shared to public

# Memory Manager Module

This module provides the `MemoryManager` class which handles the storage and retrieval of package dependencies categorized under different categories. It uses a JSON file to persist the data and ensures a default category is always present.

## Features

- **Memory Management**: Stores package dependencies in a JSON file.
- **Category Management**: Allows creating, switching, and listing categories for dependencies.
- **Dependency Management**: Adds and retrieves package dependencies within specified categories.

## Commands and Options

### 1. Create a Category

Creates a new category to organize dependencies.

**Command**:
```sh
savepip mk-category <name>
```

**Arguments**:
- `<name>` (str): The name of the category to create. IE: `savepip mk-category datascience`

**Expected Outcome**:
- If the category is created successfully, it prints a message indicating the category was created.
- If the category already exists, it prints a message indicating the category already exists.

### 2. Use a Category

Switches the current category to the specified category.

**Command**:
```sh
savepip use-category <name>
```

**Arguments**:
- `<name>` (str): The name of the category to switch to.

**Expected Outcome**:
- If the category is switched successfully, it prints a message indicating the category was switched.
- If the category does not exist, it prints a message indicating the category does not exist.

### 3. Install a Dependency

Adds a package dependency to the current category.

**Command**:
```sh
savepip install [packages]
```

**Arguments**:
- `[packages]` (list(str)): The names of the packages to add.

**Expected Outcome**:
- If the package is added successfully, it is saved in memory under the current category.
- If no category is selected, it prints a message indicating no category is selected.

### 4. Save Dependencies

Retrieves the list of package dependencies for the specified categories and save them to requirements.txt.

**Command**:
```sh
savepip save [-c [categories]]
```

**Arguments**:
- `-c [categories]` (list, optional): The list of categories to retrieve dependencies for. If not specified, retrieves dependencies for the current category.

**Expected Outcome**:
- Saves a list of package dependencies for the specified categories.

### 5. Show Current Category

Returns the name of the current category.

**Command**:
```sh
savepip cur-category
```

**Expected Outcome**:
- Returns the name of the current category.

### 6. List Categories

Lists all categories along with a flag indicating whether each category is the current category.

**Command**:
```sh
savepip ls-category
```

**Expected Outcome**:
- Returns a list of categories names and an asterisk indicating if it is the current category.

